### PR TITLE
Fixed middleware failure on HTTP 304 - Not Modified responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function liveReload(opt) {
 
     // Bypass write until end
     var inject = res.write = function(string, encoding) {
-      if (string !== undefined) { 
+      if (string !== undefined) {
         var body = string instanceof Buffer ? string.toString(encoding) : string;
         if (!snippetExists(body)) {
           res.push(body.replace(/<\/body>/, function(w) {
@@ -68,7 +68,7 @@ module.exports = function liveReload(opt) {
     // Write everything at the end
     res.end = function(string, encoding) {
       inject(string, encoding);
-  
+
       // Restore writeHead
       res.writeHead = writeHead;
       if (res.data !== undefined) {


### PR DESCRIPTION
The http server sending an HTTP 304 not modified response will break the middleware and cause it to hang up as wrapped res.end never gets called.
