### PR TITLE
Implements disableCompression option to disable gzip encoding of response

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function livereload(opt) {
     match: /<\!DOCTYPE.+>/,
     fn: append
   }];
+  var disableCompression = opt.disableCompression || false;
   var port = opt.port || 35729;
   var src = opt.src || "' + (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + port + "/livereload.js?snipver=1";
   var snippet = "\n<script type=\"text/javascript\">//<![CDATA[\ndocument.write('<script src=\"" + src + "\" type=\"text/javascript\"><\\/script>')\n//]]></script>\n";
@@ -89,6 +90,11 @@ module.exports = function livereload(opt) {
 
     if (!accept(req) || !check(req.url, include) || check(req.url, ignore)) {
       return next();
+    }
+
+    // Disable G-Zip to enable proper inspecting of HTML
+    if (disableCompression) {
+      req.headers['accept-encoding'] = 'identity';
     }
 
     function restore() {


### PR DESCRIPTION
Extract #34 into it's own branch (so you can accept the PR's separetely)

---

Livereload is not gzip-aware, so gzipped websites are not properly parsed on the "write" function.

Implementing gzip is both  
- costly (performance wise), given that it would need to uncompress and compress every gzipped response, and
- difficult, given that "write" is synchronous and node zlib methods are all async.

Therefore, a simpler solution for development purposes is to simply remove the "Accept-Encoding" header sent by the browser.
