### PR TITLE
Injected snippet improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function livereload(opt) {
   }];
   var disableCompression = opt.disableCompression || false;
   var port = opt.port || 35729;
-  var src = opt.src || "' + (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + port + "/livereload.js?snipver=1";
+  var src = opt.src || "//' + (location.hostname || 'localhost') + ':" + port + "/livereload.js?snipver=1";
   var snippet = "\n<script>//<![CDATA[\ndocument.write('<script src=\"" + src + "\"><\\/script>')\n//]]></script>\n";
 
   // helper functions


### PR DESCRIPTION
1. Default value of `type` attribute for `<script>` element is `text/javascript` so there’s no point in using it, [see HTML5 spec](http://www.w3.org/TR/html5/scripting-1.html#attr-script-type).
2. Instead of using protocol from options it’s much easier to use protocol-relative URL, basically `src="//` which will resolve file with protocol of the current page, see [RFC 1808](http://www.ietf.org/rfc/rfc1808.txt) and [The Protocol-relative URL](http://www.paulirish.com/2010/the-protocol-relative-url/) article by @paulirish

Snippet output before (some line breaks added)

```
<script type="text/javascript">//<![CDATA[
document.write('<script src="' + (location.protocol || 'http:') + '//' +
(location.hostname || 'localhost') +
':35729/livereload.js?snipver=1" type="text/javascript"><\/script>')
//]]></script>
…
<script src="http://localhost:35729/livereload.js?snipver=1" type="text/javascript"></script>
```

Snippet output after:

```
<script>//<![CDATA[
document.write('<script src="//' +
(location.hostname || 'localhost') +
':35729/livereload.js?snipver=1"><\/script>')
//]]></script>
…
<script src="//localhost:35729/livereload.js?snipver=1"></script>
```
