### PR TITLE
Doesn't work on minimal HTML5 pages that have lowercase doctypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,13 @@ module.exports = function livereload(opt) {
   var include = opt.include || [/.*/];
   var html = opt.html || _html;
   var rules = opt.rules || [{
-    match: /<\/body>(?![\s\S]*<\/body>)/,
+    match: /<\/body>(?![\s\S]*<\/body>)/i,
     fn: prepend
   }, {
-    match: /<\/html>(?![\s\S]*<\/html>)/,
+    match: /<\/html>(?![\s\S]*<\/html>)/i,
     fn: prepend
   }, {
-    match: /<\!DOCTYPE.+>/,
+    match: /<\!DOCTYPE.+>/i,
     fn: append
   }];
   var disableCompression = opt.disableCompression || false;


### PR DESCRIPTION
I noticed that my minimal HTML5 page stopped livereloading when I changed my doctype to lowercase. I changed the regular expressions to be case insensitive, which is still valid HTML5.

References: #12 and 0d8c0dd
