### PR TITLE
Do not change PDF content

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function livereload(opt) {
 
   function _html(str) {
     if (!str) return false;
+    if (str.substr(0, 5) == "%PDF-") return false;
     return /<[:_-\w\s\!\/\=\"\']+>/i.test(str);
   }
 


### PR DESCRIPTION
Hi,
there is a small bug, when the Browser sends an Accept-Header containing "html", connect-livereload will change PDF Files because the Regex in "function _html()" will match. To prevent this, I added a small check.
Dennis
