### PR TITLE
Fix injection bug when html is minified

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function livereload(opt) {
     match: /<\/html>(?![\s\S]*<\/html>)/i,
     fn: prepend
   }, {
-    match: /<\!DOCTYPE.+>/i,
+    match: /<\!DOCTYPE.+?>/i,
     fn: append
   }];
   var disableCompression = opt.disableCompression || false;


### PR DESCRIPTION
Make doctype regex less greedy, otherwise it may inject in an illegal place. Example:

``` html
<!DOCTYPE html><html><head><style>
<script>//<![CDATA[
document.write('<script src="//' + (location.hostname || 'localhost') + ':35729/livereload.js?snipver=1"><\/script>')
//]]></script>
.some-static-css {
  /* ... */
}
</style>
```
