### PR TITLE
Remove hard-coded `/livereload.js` in place of `src` which will allow cu...

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function livereload(opt) {
 
   function snip(body) {
     if (!body) return false;
-    return (~body.lastIndexOf("/livereload.js"));
+    return (~body.lastIndexOf(src));
   }
 
   function snap(body) {

--- a/test/app.options.src.js
+++ b/test/app.options.src.js
@@ -1,0 +1,54 @@
+var express = require("express");
+var app = express();
+
+// set a custom URL for script src
+app.configure('development', function() {
+  // live reload script
+  app.use(require('../index.js')({
+    src: "http://localhost:3000/browser-sync/browser-sync-client.js"
+  }));
+});
+
+
+// load static content before routing takes place
+app.use(express["static"](__dirname + "/fixtures"));
+
+// load the routes
+app.use(app.router);
+app.get("/default-test", function(req, res) {
+  var html = '<html><head></head><body><p>default test </p></body></html>';
+  res.send(html);
+});
+
+app.get("/index.html", function(req, res) {
+  var html = '<html><head></head><body><p>default test </p></body></html>';
+  res.send(html);
+});
+
+// start the server
+if (!module.parent) {
+  var port = settings.webserver.port || 3000;
+  app.listen(port);
+  console.log("Express app started on port " + port);
+}
+
+// run the tests
+var request = require('supertest');
+var assert = require('assert');
+
+
+describe('GET /default-test', function(){
+  it('respond with inserted script', function(done){
+    request(app)
+      .get('/default-test')
+      .set('Accept', 'text/html')
+      .expect(200)
+      .end(function(err, res){
+
+        var match = res.text.match(new RegExp("http://localhost:3000/browser-sync/browser-sync-client.js", "g"));
+        assert.equal(match.length, 1);
+        if (err) return done(err);
+        done()
+      });
+  })
+})


### PR DESCRIPTION
...stom script src's to operate as expected.

Because the `snip` function has the hardcoded value, any attempt to use a custom `src` option results in the snippet being written to the response twice.

The test I added simply verifies that the src is only written once.