### PR TITLE
Ignore .json files by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ module.exports = function livereload(opt) {
   // options
   var opt = opt || {};
   var ignore = opt.ignore || opt.excludeList || [/\.js(\?.*)?$/, /\.css(\?.*)?$/, /\.svg(\?.*)?$/, /\.ico(\?.*)?$/,
-    /\.woff(\?.*)?$/, /\.png(\?.*)?$/, /\.jpg(\?.*)?$/, /\.jpeg(\?.*)?$/, /\.gif(\?.*)?$/, /\.pdf(\?.*)?$/
+    /\.woff(\?.*)?$/, /\.png(\?.*)?$/, /\.jpg(\?.*)?$/, /\.jpeg(\?.*)?$/, /\.gif(\?.*)?$/, /\.pdf(\?.*)?$/,
+    /\.json(\?.*)?$/
   ];
 
   var include = opt.include || [/.*/];


### PR DESCRIPTION
I had problems with a JSON file which contained SVG code for spriting. It may make sense to ignore .json files by default.