### PR TITLE
Fix call to inject() to add missing encoding parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ module.exports = function livereload(opt) {
 
       // If there are remaining bytes, save them as well
       // Also, some implementations call "end" directly with all data.
-      res.inject(string);
+      res.inject(string, encoding);
       runPatches = false;
       // Check if our body is HTML, and if it does not already have the snippet.
       if (html(res.data) && exists(res.data) && !snip(res.data)) {


### PR DESCRIPTION
If the encoding was not 'utf-8', the contents added via the http response.end() call were not correct.