### PR TITLE
Support injecting livereload plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ These are the available options with the following defaults:
 
   // Set this option to `true` to set `req.headers['accept-encoding']` to 'identity' (disabling compression)
   disableCompression: false,
+
+  // Locations where livereload plugins are provided (not by connect-livereload).
+  // These plugins should handle being loaded before _or_ after the livereload
+  // script itself (the order is not guaranteed), like
+  // https://github.com/mixmaxhq/livereload-require-js-includes/blob/5a431793d6fdfcf93d66814ddc58338515a3254f/index.js#L40-L45
+  plugins: [
+    "http://localhost:3001/livereload-require-js-includes/index.js"
+  ]
 ```
 
 please see the [examples](https://github.com/intesso/connect-livereload/tree/master/examples) for the app and Grunt configuration.

--- a/index.js
+++ b/index.js
@@ -20,10 +20,14 @@ module.exports = function livereload(opt) {
     }];
   var disableCompression = opt.disableCompression || false;
   var port = opt.port || 35729;
+  var plugins = opt.plugins || [];
 
   function snippet(host) {
     var src = opt.src || '//' + host + ':' + port + '/livereload.js?snipver=1';
-    return '<script src="' + src + '" async="" defer=""></script>';
+    return '<script src="' + src + '" async="" defer=""></script>' +
+      plugins.map(function(pluginSrc) {
+        return '<script src="' + pluginSrc + '" async="" defer=""></script>';
+      }).join('');
   }
 
   // helper functions

--- a/index.js
+++ b/index.js
@@ -24,10 +24,9 @@ module.exports = function livereload(opt) {
 
   function snippet(host) {
     var src = opt.src || '//' + host + ':' + port + '/livereload.js?snipver=1';
-    return '<script src="' + src + '" async="" defer=""></script>' +
-      plugins.map(function(pluginSrc) {
-        return '<script src="' + pluginSrc + '" async="" defer=""></script>';
-      }).join('');
+    return [src].concat(plugins).map(function(source) {
+      return '<script src="' + source + '" async="" defer=""></script>';
+    }).join('');
   }
 
   // helper functions

--- a/test/app.options.plugins.js
+++ b/test/app.options.plugins.js
@@ -1,0 +1,53 @@
+var express = require("express");
+var app = express();
+
+// load liveReload script and plugin
+app.use(require('../index.js')({
+  plugins: [
+    "http://localhost/plugin.js"
+  ]
+}));
+
+// load static content before routing takes place
+app.use(express["static"](__dirname + "/fixtures"));
+
+app.get("/default-test", function (req, res) {
+  var html = '<html><head></head><body><p>default test </p></body></html>';
+  res.send(html);
+});
+
+app.get("/index.html", function (req, res) {
+  var html = '<html><head></head><body><p>default test </p></body></html>';
+  res.send(html);
+});
+
+// start the server
+if (!module.parent) {
+  var port = settings.webserver.port || 3000;
+  app.listen(port);
+  console.log("Express app started on port " + port);
+}
+
+// run the tests
+var request = require('supertest');
+var assert = require('assert');
+
+
+describe('GET /default-test', function () {
+  it('respond with inserted script and plugin', function (done) {
+    request(app)
+      .get('/default-test')
+      .set('Accept', 'text/html')
+      .expect(200)
+      .end(function (err, res) {
+        // Assert that it has the script.
+        assert(~res.text.indexOf('livereload.js?snipver=1'));
+
+        // Assert that it has the plugin.
+        assert(~res.text.indexOf('plugin.js'));
+
+        if (err) return done(err);
+        done()
+      });
+  })
+});


### PR DESCRIPTION
The LiveReload client supports plugins to handle reload requests for various filepaths. I can't find documentation for them online, found this support [in the client's source](https://github.com/livereload/livereload-js/blob/e1d943628005ad8d18a50ee1e8c29858ca748d10/dist/livereload.js#L760), but here's an example: https://github.com/mixmaxhq/livereload-require-js-includes

This PR adds support for injecting such plugins alongside the livereload script.