### PR TITLE
Exclude extensions refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function livereload(opt) {
   // options
   opt = opt || {};
-  var excludeExtensions = ['js', 'css', 'svg', 'ico', 'woff', 'png', 'jpg', 'jpeg', 'gif', 'pdf', 'json'];
+  var excludeExtensions = ['js', 'css', 'svg', 'ico', 'woff', 'png', 'jpg', 'jpeg', 'gif', 'pdf', 'json', 'zip', 'rar', 'tar', 'gz'];
   var ignore = opt.ignore || opt.excludeList || excludeExtensions.map(function (ext) {
 	  return new RegExp('\\.' + ext + '(\\?.*)?$');
   });

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 module.exports = function livereload(opt) {
   // options
   opt = opt || {};
-  var ignore = opt.ignore || opt.excludeList || [/\.js(\?.*)?$/, /\.css(\?.*)?$/, /\.svg(\?.*)?$/, /\.ico(\?.*)?$/,
-    /\.woff(\?.*)?$/, /\.png(\?.*)?$/, /\.jpg(\?.*)?$/, /\.jpeg(\?.*)?$/, /\.gif(\?.*)?$/, /\.pdf(\?.*)?$/,
-    /\.json(\?.*)?$/
-  ];
+  var excludeExtensions = ['js', 'css', 'svg', 'ico', 'woff', 'png', 'jpg', 'jpeg', 'gif', 'pdf', 'json'];
+  var ignore = opt.ignore || opt.excludeList || excludeExtensions.map(function (ext) {
+	  return new RegExp('\\.' + ext + '(\\?.*)?$');
+  });
 
   var include = opt.include || [/.*/];
   var html = opt.html || _html;


### PR DESCRIPTION
Two changes:
1. Move exclude extensions to array and map it with regexp. So now it is much more readable and easy to add new extensions
2. Added exclude extensions for archives: zip, rar, tar, gz. (It is related to #39 )